### PR TITLE
Add Clear button, add Domain header, housekeeping

### DIFF
--- a/popup/css/popup-stylesheet.css
+++ b/popup/css/popup-stylesheet.css
@@ -2,10 +2,6 @@
 	display: block;
 }
 
-.gap {
-	gap: 16px;
-}
-
 .flex {
 	flex : 1;
 }
@@ -22,7 +18,9 @@
 	flex-direction: row;
 }
 
-
+.gap {
+	gap: 16px;
+}
 
 
 body {

--- a/popup/css/popup-stylesheet.css
+++ b/popup/css/popup-stylesheet.css
@@ -2,12 +2,12 @@
 	display: block;
 }
 
-.flex {
-	flex : 1;
+.gap {
+	gap: 16px;
 }
 
-.viewport {
-
+.flex {
+	flex : 1;
 }
 
 .flex-container {
@@ -22,46 +22,25 @@
 	flex-direction: row;
 }
 
-.popup-button {
-	background-color: aliceblue;
-	border: none;
-	border-radius: 4px;
 
-	margin-left: 25px;
-	margin-right: 25px;
-
-	font-size: 1.5em;
-	text-align: center;
-}
-
-.downward-box-shadow {
-	-webkit-box-shadow: 0px 2px 5px 0px rgba(0,0,0,0.75);
-	-moz-box-shadow: 0px 2px 5px 0px rgba(0,0,0,0.75);
-	box-shadow: 0px 2px 5px 0px rgba(0,0,0,0.75);
-}
-
-.active-reset-button {
-	background-color: #FFC24B;
-}
 
 
 body {
 	background-color: #eaeaea;
 }
 
+button {
+	padding: 8px;
+}
 
 #popup-viewport {
 	width: 370px;
-	height: 400px;
+	height: auto;
+	overflow: hidden;
 }
 
 #hostname-container {
-	display: none;
-
-	width: 370px;
-	height: 25px;
-	
-	margin-bottom: 5px;
+	margin-bottom: 8px;
 
 	font-size: 1em;
 
@@ -69,6 +48,7 @@ body {
 	
 	border: 1px solid black;
 	border-radius: 4px;
+	padding: 4px;
 }
 
 #textbox-container {
@@ -80,21 +60,12 @@ body {
 	width: 370px;
 	height: 310px;
 
-	margin-bottom: 10px;
+	margin-bottom: 8px;
 
 	background-color: #230000;
 	color: #ebffe0;
 }
 
 #controls-container {
-	padding: 10px;
-}
-
-#reset-button {
-	border: 1px solid #FFC24B;
-	background-color none: 
-}
-
-#apply-button {
-	background-color: #8EFF68;
+	padding: 16px 8px;
 }

--- a/popup/js/popup.js
+++ b/popup/js/popup.js
@@ -417,7 +417,7 @@ function getTabUrl() {
       console.log(`hostname: ${hostname}`);
     }
 
-    hostnameContainer.innerHTML = hostname
+    hostnameContainer.textContent = hostname;
 
     let getHostnamePromise = browser.storage.sync.get(hostname);
 

--- a/popup/style_editor.html
+++ b/popup/style_editor.html
@@ -3,24 +3,26 @@
   <head>
     <meta charset="UTF-8">
     <title>Custom Style Manager</title>
-  	<link rel="stylesheet" href="css/popup-stylesheet.css" type="text/css">
+    <link rel="stylesheet" href="css/popup-stylesheet.css" type="text/css">
   </head>
 
   <body>
 
-	<p id = "hostname-container" class = "flex block-container"> </p>
-  	<div id = "popup-viewport" class = "viewport flex-container flex-vertical-container">
-  		<div id = "textbox-container" class = "flex block-container">
-  			<textarea id = "popup-textarea" class = "block-container" spellcheck = "false"></textarea>
-  		</div>
-  		<div id = "controls-container" class = "flex flex-container flex-horizontal-container">
-  			<button id = "reset-button" class = "popup-button flex"> Reset </button>
-  			<button id = "apply-button" class = "downward-box-shadow popup-button flex"> Apply </button>
-  		</div>
-  	</div>
 
-  	<script src = "../rules.json"></script>
-  	<script src = "js/popup.js"></script>
+    <div id = "popup-viewport" class = "viewport flex-container flex-vertical-container">
+      <p id = "hostname-container" class = "flex block-container"> </p>
+      <div id = "textbox-container" class = "flex block-container">
+        <textarea id = "popup-textarea" class = "block-container" spellcheck = "false"></textarea>
+      </div>
+      <div id = "controls-container" class = "gap flex flex-container flex-horizontal-container">
+        <button id = "clear-button" class = "popup-button flex"> Clear </button>
+        <button id = "reset-button" class = "popup-button flex"> Undo </button>
+        <button id = "apply-button" class = "downward-box-shadow popup-button flex"> Apply </button>
+      </div>
+    </div>
+
+    <script src = "../rules.json"></script>
+    <script src = "js/popup.js"></script>
 
   </body>
 </html>


### PR DESCRIPTION
This PR primarily adds a Clear button, but in addition:

- hostname was added as a header

There was a Paragraph element hidden in the panel, so I repurposed it to show the domain.

- text box changes

I was confused as both a user and a developer looking at code, seeing the "Oops..." message, so this was clarified. Also, the text field has been emptied out when visiting a new domain. This prevents the need for users to manually delete the text each time. 

- CSS simplification

I didn't think the extension had much of an identity, so I simplified the look across the board. This fixed a design bug in which button clicks (ie `active` state) had no visual distinction. I realize this is somewhat up to taste but I think it's an improvement until a stronger design is presented:

![image](https://github.com/HalilCan/customStyleManager/assets/843112/bb59ae48-07a0-400e-90ed-d9ad32762fa7)

- restructuring

This is pretty minor, but it helped me understand the structure of the code better when I was looking at making changes

- white-space nonsense erring towards consistency